### PR TITLE
replace md5 digest with sha256 in getdgraph.sh

### DIFF
--- a/getdgraph.sh
+++ b/getdgraph.sh
@@ -70,13 +70,16 @@ printf $RESET
 	print_step "Latest release version is $release_version."
 
 	platform="$(uname | tr '[:upper:]' '[:lower:]')"
-	if [ "$platform" = "linux" ]; then
-		md5cmd=md5sum
+
+	digest_cmd=""
+	if hash shasum 2>/dev/null; then
+	  digest_cmd="shasum -a 256"
 	else
-		md5cmd="md5 -r"
+	  print_error "Could not find shasum. Please install shasum and try again.";
+	  exit 1
 	fi
 
-	checksum_file="dgraph-checksum-$platform-amd64-$release_version".md5
+	checksum_file="dgraph-checksum-$platform-amd64-$release_version".sha256
 	checksum_link="https://github.com/dgraph-io/dgraph/releases/download/"$release_version"/"$checksum_file
 	print_step "Downloading checksum file."
 	if curl -L --progress-bar "$checksum_link" -o "/tmp/$checksum_file"; then
@@ -92,9 +95,9 @@ printf $RESET
 
 	print_step "Comparing checksums for dgraph binaries"
 
-	if $md5cmd /usr/local/bin/dgraph &>/dev/null && $md5cmd /usr/local/bin/dgraphloader &>/dev/null; then
-		dgraphsum=$($md5cmd /usr/local/bin/dgraph | awk '{print $1;}')
-		dgraphloadersum=$($md5cmd /usr/local/bin/dgraphloader | awk '{print $1;}')
+	if $digest_cmd /usr/local/bin/dgraph &>/dev/null && $digest_cmd /usr/local/bin/dgraphloader &>/dev/null; then
+		dgraphsum=$($digest_cmd /usr/local/bin/dgraph | awk '{print $1;}')
+		dgraphloadersum=$($digest_cmd /usr/local/bin/dgraphloader | awk '{print $1;}')
 	else
 		dgraphsum=""
 		dgraphloadersum=""
@@ -143,8 +146,8 @@ printf $RESET
 
 	icufile="icudt58l.dat"
 	iculoc="/usr/local/share/$icufile"
-	if $md5cmd $iculoc &>/dev/null; then
-		icusum=$($md5cmd $iculoc | awk '{print $1;}')
+	if $digest_cmd $iculoc &>/dev/null; then
+		icusum=$($digest_cmd $iculoc | awk '{print $1;}')
 	else
 		icusum=""
 	fi


### PR DESCRIPTION
Fixes the other half of https://github.com/dgraph-io/dgraph/issues/446 by verifying the message digest with sha256 instead of MD5. Uses `shasum` as the command on both macOS and linux systems. Manually tested on macOS 10.12.2, Ubuntu, and Arch Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/website/3)
<!-- Reviewable:end -->
