### PR TITLE
replace "throughout" with "throughput" on title page

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,9 +246,9 @@
                 </header>
                 <ul class="dg-features__list">
                   <li class="dg-features__item">
-                    <div class="dg-features__figure"><img src="assets/images/homepage/feature-01.svg" alt="Image for low latency, high throughout feature" class="dg-features__image"></div>
+                    <div class="dg-features__figure"><img src="assets/images/homepage/feature-01.svg" alt="Image for low latency, high throughput feature" class="dg-features__image"></div>
                     <div class="dg-features__description">
-                      <h4 class="dg-features__title">Low Latency, High Throughout</h4>
+                      <h4 class="dg-features__title">Low Latency, High Throughput</h4>
                       <p>Storage layer of Dgraph is designed for efficient retrieval, it offers low enough latency to be serving real time user queries, over terabytes of structured data.</p>
                     </div>
                   </li>

--- a/source/site-pages/index.jade
+++ b/source/site-pages/index.jade
@@ -67,9 +67,9 @@ block page-content
 							ul.dg-features__list
 								li.dg-features__item
 									.dg-features__figure
-										img(src="assets/images/homepage/feature-01.svg", alt="Image for low latency, high throughout feature").dg-features__image
+										img(src="assets/images/homepage/feature-01.svg", alt="Image for low latency, high throughput feature").dg-features__image
 									.dg-features__description
-										h4.dg-features__title Low Latency, High Throughout
+										h4.dg-features__title Low Latency, High Throughput
 										p Storage layer of Dgraph is designed for efficient retrieval, it offers low enough latency to be serving real time user queries, over terabytes of structured data.
 								li.dg-features__item
 									.dg-features__figure


### PR DESCRIPTION
On title page, replace "throughout" with "throughput".